### PR TITLE
未设置图灵Key状态下，默认返回 "忙着呢，别烦我"

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -13,7 +13,6 @@ import os
 '''
 bot = Bot('bot.pkl', console_qr=True)
 bot.messages.max_history = 0
-tuling = Tuling(api_key=turing_key)
 
 '''
 开启 PUID 用于后续的控制
@@ -206,7 +205,12 @@ def wxpy_group(msg):
     if ret_msg:
         return ret_msg
     elif msg.is_at:
-        tuling.do_reply(msg)
+        if turing_key :
+            tuling = Tuling(api_key=turing_key)
+            tuling.do_reply(msg)
+        else:
+            return "忙着呢，别烦我！";
+            pass
 
 
 @bot.register(groups, NOTE)


### PR DESCRIPTION


## 描述
未设置图灵Key状态下，默认返回 "忙着呢，别烦我"
## 动机或前后关系
未设置图灵Key情况下的兼容

## 如何测试相关代码
保持图灵机器人的key为空的情况下，默认返回 "忙着呢，别烦我"



## 变更类型
<!--- 选择你的代码的类型，在前面的 `[ ]` 中填入一个 x 即可 -->
- [ ] 修复Bug (non-breaking change which fixes an issue)
- [x] 新特性 (non-breaking change which adds functionality)
- [ ] 较大变化 (fix or feature that would cause existing functionality to change)

## 检查清单:
<!--- 提交前确保完成下述动作 -->
<!--- 如果你不清楚这些，不要害羞，向我们提问吧! -->
- [x] 我的代码遵循了项目的代码风格
- [ ] 我的代码需要更改文档
- [ ] 我相应的更新了文档
- [ ] 我查看了 **CONTRIBUTING** 文档.