### PR TITLE
关闭未设置图灵key情况下的默认返回

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -241,10 +241,6 @@ def wxpy_group(msg):
         if turing_key :
             tuling = Tuling(api_key=turing_key)
             tuling.do_reply(msg)
-        else:
-            return "忙着呢，别烦我！";
-            pass
-
 
 @bot.register(groups, NOTE)
 def welcome(msg):


### PR DESCRIPTION
## 描述
关闭未设置图灵key情况下的默认返回

## 动机或前后关系
未设置图灵 Key 时不回复群聊 at，以免被误认为聊天机器人而不停被 at

## 如何测试相关代码

## 截图 (如果方便的话):

## 变更类型
<!--- 选择你的代码的类型，在前面的 `[ ]` 中填入一个 x 即可 -->
- [ ] 修复Bug (non-breaking change which fixes an issue)
- [ ] 新特性 (non-breaking change which adds functionality)
- [ ] 较大变化 (fix or feature that would cause existing functionality to change)

## 检查清单:
<!--- 提交前确保完成下述动作 -->
<!--- 如果你不清楚这些，不要害羞，向我们提问吧! -->
- [x] 我的代码遵循了项目的代码风格
- [ ] 我的代码需要更改文档
- [ ] 我相应的更新了文档
- [x] 我查看了 **CONTRIBUTING** 文档.
